### PR TITLE
Fix Sphinx not generating docs

### DIFF
--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -2,6 +2,7 @@ name: Build Docs
 
 on:
   push:
+  pull_request:
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -1,0 +1,56 @@
+name: Build Docs
+
+on:
+  push:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout self
+        uses: actions/checkout@v6
+        with:
+          path: StarlitLibrary
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "StarlitLibrary/docs/requirements.txt"
+
+      - name: Install dependencies
+        run: pip install -r StarlitLibrary/docs/requirements.txt
+
+      - name: Get Umbrella remote SHA
+        id: get-umbrella-remote-sha
+        run: |
+          SHA=$(git ls-remote https://github.com/PZ-Umbrella/Umbrella.git HEAD | cut -f1)
+          echo "UMBRELLA_HEAD_SHA=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Setup Umbrella (using cache)
+        id: cache-umbrella-repo
+        uses: actions/cache@v5
+        with:
+          path: ./vendor/Umbrella
+          key: vendor-umbrella-${{ steps.get-umbrella-remote-sha.outputs.UMBRELLA_HEAD_SHA }}
+
+      - name: Setup Umbrella
+        if: steps.cache-umbrella-repo.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth=1 --no-tags https://github.com/PZ-Umbrella/Umbrella.git vendor/Umbrella
+          cd vendor/Umbrella/library
+          echo "PZ_UMBRELLA=$(pwd)" >> $GITHUB_ENV
+          cd ../../../
+
+      - name: Build website with Sphinx
+        run: |
+          cd StarlitLibrary/docs
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: StarlitLibrary/docs/build/html

--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -45,6 +45,7 @@ jobs:
           cd vendor/Umbrella/library
           echo "PZ_UMBRELLA=$(pwd)" >> $GITHUB_ENV
           cd ../../../
+          echo "PZ_UMBRELLA set to: $PZ_UMBRELLA"
 
       - name: Build website with Sphinx
         run: |

--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -38,10 +38,13 @@ jobs:
           path: ./vendor/Umbrella
           key: vendor-umbrella-${{ steps.get-umbrella-remote-sha.outputs.UMBRELLA_HEAD_SHA }}
 
-      - name: Setup Umbrella
+      - name: Setup Umbrella repo
         if: steps.cache-umbrella-repo.outputs.cache-hit != 'true'
         run: |
           git clone --depth=1 --no-tags https://github.com/PZ-Umbrella/Umbrella.git vendor/Umbrella
+          
+      - name: Set Umbrella env var
+        run: |
           cd vendor/Umbrella/library
           echo "PZ_UMBRELLA=$(pwd)" >> $GITHUB_ENV
           cd ../../../

--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -3,6 +3,7 @@ name: Build Docs
 on:
   push:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -45,10 +45,10 @@ jobs:
           cd vendor/Umbrella/library
           echo "PZ_UMBRELLA=$(pwd)" >> $GITHUB_ENV
           cd ../../../
-          echo "PZ_UMBRELLA set to: $PZ_UMBRELLA"
 
       - name: Build website with Sphinx
         run: |
+          echo "PZ_UMBRELLA is set to: $PZ_UMBRELLA"
           cd StarlitLibrary/docs
           make html
 

--- a/.github/workflows/buildDocs.yml
+++ b/.github/workflows/buildDocs.yml
@@ -13,18 +13,16 @@ jobs:
     steps:
       - name: Checkout self
         uses: actions/checkout@v6
-        with:
-          path: StarlitLibrary
 
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: "pip"
-          cache-dependency-path: "StarlitLibrary/docs/requirements.txt"
+          cache-dependency-path: "docs/requirements.txt"
 
       - name: Install dependencies
-        run: pip install -r StarlitLibrary/docs/requirements.txt
+        run: pip install -r docs/requirements.txt
 
       - name: Get Umbrella remote SHA
         id: get-umbrella-remote-sha
@@ -53,10 +51,10 @@ jobs:
       - name: Build website with Sphinx
         run: |
           echo "PZ_UMBRELLA is set to: $PZ_UMBRELLA"
-          cd StarlitLibrary/docs
+          cd docs
           make html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: StarlitLibrary/docs/build/html
+          path: docs/build/html

--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -3,37 +3,12 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout self
-        uses: actions/checkout@v6.0.2
-        with:
-          path:
-            StarlitLibrary
-      
-      - name: Setup Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: '3.13'
-          cache: 'pip'
-          cache-dependency-path: 'StarlitLibrary/docs/requirements.txt'
-      
-      - name: Install dependencies
-        run: pip install -r StarlitLibrary/docs/requirements.txt
-      
-      - name: Build website with Sphinx
-        run: |
-          cd StarlitLibrary/docs
-          make html
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4.0.0
-        with:
-          path: StarlitLibrary/docs/build/html
+    name: Build
+    uses: ./.github/workflows/buildDocs.yml
 
   deploy:
     needs: build
@@ -45,4 +20,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to pages
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx~=8.2.0
-sphinx-lua-ls==3.11.0
-sphinx-rtd-theme~=3.0.2
+sphinx~=9.1.0
+sphinx-lua-ls~=3.11.0
+sphinx-rtd-theme~=3.1.0


### PR DESCRIPTION
Turns out this is due to the Umbrella environment variable `$PZ_UMBRELLA` not being setup. For some reason, this must have recently become required for EmmyLua, otherwise something in emmylua-doc-cli will autofail and not proceed further, resulting in no Lua objects parsed.

Fixes #53 